### PR TITLE
Refactoring exercise Alexandre Lacheze

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,25 @@
 // This file has to be left untouched
 
 import React, { Component } from 'react';
-import DomainFilter from './components/DomainFilter';
+import DomainFilter, { FilterValue, defaultFilterValue } from './components/DomainFilter';
 
-class App extends Component {
+
+type State = {
+  filterValue: FilterValue;
+}
+class App extends Component<{}, State> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { filterValue: defaultFilterValue };
+  }
+  
   render() {
     return (
       <div className="App">
-        <DomainFilter />
+        <DomainFilter
+          value={this.state.filterValue}
+          onValueChange={(v: FilterValue) => this.setState({ filterValue: v })}
+        />
       </div>
     );
   }

--- a/src/components/DomainFilter/DomainFilter.component.tsx
+++ b/src/components/DomainFilter/DomainFilter.component.tsx
@@ -20,29 +20,11 @@ class DomainFilter extends React.Component<Props, State> {
       subClassifications: []
     }
 
-    const s: any = {};
-
-    for(let i = 0; i < domains.length; i++) {
-      if (this.state.countries.indexOf(domains[i].substring(0,2)) <= 0) {
-        this.state.countries.push(domains[i].substring(0,2))
-      }
-      this.state.classifications.push(domains[i].substring(3,5));
-      let flag = false;
-      for(let j = 0; j < this.state.subClassifications.length; j++) {
-        if (this.state.subClassifications[j] == domains[i].substring(6)) {
-          flag = true
-          break;
-        }
-      }
-      if (!flag) {
-        this.state.subClassifications.push(domains[i].substring(6));
-      }
-    }
-
     this.setState({
       ...this.state,
-      classifications: this.state.classifications.filter((e, i, l) => l.indexOf(e) === i),
+      ...domainsToOptions(domains),
     })
+
     this.forceUpdate()
   }
 
@@ -71,6 +53,45 @@ class DomainFilter extends React.Component<Props, State> {
       </select>
     </>)
   }
+}
+
+type Options = {
+  countries: string[],
+  classifications: string[],
+  subClassifications: string[]
+}
+
+/**
+ * Will transform a set of domains into availabale options for country code, classifications, sub classifications.
+ */
+export const domainsToOptions = (domains: string[]): Options => {
+  const options: Options = {
+    countries: [],
+    classifications: [],
+    subClassifications: [],
+  };
+
+  // todo(al): possible to clean this logic?
+  for (let i = 0; i < domains.length; i++) {
+    if (options.countries.indexOf(domains[i].substring(0, 2)) <= 0) {
+      options.countries.push(domains[i].substring(0, 2))
+    }
+    options.classifications.push(domains[i].substring(3, 5));
+    let flag = false;
+    for (let j = 0; j < options.subClassifications.length; j++) {
+      if (options.subClassifications[j] == domains[i].substring(6)) {
+        flag = true
+        break;
+      }
+    }
+    if (!flag) {
+      options.subClassifications.push(domains[i].substring(6));
+    }
+
+    options.classifications = options.classifications.filter((e, i, l) => l.indexOf(e) === i);
+  }
+
+  return options;
 }
 
 export default DomainFilter

--- a/src/components/DomainFilter/DomainFilter.component.tsx
+++ b/src/components/DomainFilter/DomainFilter.component.tsx
@@ -1,39 +1,18 @@
 import React from 'react';
 import { threadId } from 'worker_threads';
 
-interface State {
-  countries: string[],
-  classifications: string[],
-  subClassifications: string[]
-}
+interface State {}
 
 interface Props {
   domains: string[]
 }
 
 class DomainFilter extends React.Component<Props, State> {
-  componentDidMount() {
-    const { domains } = this.props
-    this.state = {
-      countries: [],
-      classifications: [],
-      subClassifications: []
-    }
-
-    this.setState({
-      ...this.state,
-      ...domainsToOptions(domains),
-    })
-
-    this.forceUpdate()
-  }
 
   render() {
-    const {countries, classifications, subClassifications} = this.state || {
-      countries: [],
-      classifications: [],
-      subClassifications: []
-    };
+    const { domains } = this.props
+
+    const { countries, classifications, subClassifications } = domainsToOptions(domains);
 
     return (<>
       <select name="countries" multiple>

--- a/src/components/DomainFilter/DomainFilter.component.tsx
+++ b/src/components/DomainFilter/DomainFilter.component.tsx
@@ -1,32 +1,56 @@
 import React from 'react';
 import { threadId } from 'worker_threads';
 
-interface State {}
 
-interface Props {
-  domains: string[]
+export type FilterValue = {
+  country: string[],
+  classification: string[],
+  subClassification: string[]
 }
 
-class DomainFilter extends React.Component<Props, State> {
+export const defaultFilterValue: FilterValue = { country: [], classification: [], subClassification: [] }
+
+interface Props {
+  domains: string[];
+  value: FilterValue;
+  onValueChange?: (value: FilterValue) => void;
+}
+
+class DomainFilter extends React.Component<Props> {
 
   render() {
-    const { domains } = this.props
+    const { domains, value, onValueChange } = this.props;
 
     // todo(alexstrat): add memoization here for the peace of mind
     const { countries, classifications, subClassifications } = domainsToOptions(domains);
 
     return (<>
-      <select name="countries" multiple>
+      <select
+        name="countries"
+        multiple
+        value={value.country || undefined}
+        onChange={(e) => onValueChange && onValueChange({...value, country: [e.target.value]})}
+      >
         {countries.map(country => (
           <option value={country} key={country}>{country}</option>
         ))}
       </select>
-      <select name="classifications" multiple>
+      <select
+        name="classifications"
+        multiple
+        value={value.classification || undefined}
+        onChange={(e) => onValueChange && onValueChange({ ...value, classification: [e.target.value] })}
+      >
         {classifications.map(classification => (
           <option value={classification} key={classification}>{classification}</option>
         ))}
       </select>
-      <select name="subClassifications" multiple>
+      <select
+        name="subClassifications"
+        multiple
+        value={value.subClassification || undefined}
+        onChange={(e) => onValueChange && onValueChange({ ...value, subClassification: [e.target.value] })}
+      >
         {subClassifications.map(subClassification => (
           <option value={subClassification} key={subClassification}>{subClassification}</option>
         ))}

--- a/src/components/DomainFilter/DomainFilter.component.tsx
+++ b/src/components/DomainFilter/DomainFilter.component.tsx
@@ -51,7 +51,7 @@ export const domainsToOptions = (domains: string[]): Options => {
     subClassifications: [],
   };
 
-  // todo(al): possible to clean this logic?
+  // todo(alexstrat): possible to clean this logic?
   for (let i = 0; i < domains.length; i++) {
     if (options.countries.indexOf(domains[i].substring(0, 2)) <= 0) {
       options.countries.push(domains[i].substring(0, 2))

--- a/src/components/DomainFilter/DomainFilter.component.tsx
+++ b/src/components/DomainFilter/DomainFilter.component.tsx
@@ -12,6 +12,7 @@ class DomainFilter extends React.Component<Props, State> {
   render() {
     const { domains } = this.props
 
+    // todo(alexstrat): add memoization here for the peace of mind
     const { countries, classifications, subClassifications } = domainsToOptions(domains);
 
     return (<>

--- a/src/components/DomainFilter/DomainFilter.container.ts
+++ b/src/components/DomainFilter/DomainFilter.container.ts
@@ -1,4 +1,4 @@
-import DomainFilter from './DomainFilter.component';
+import DomainFilter, { FilterValue } from './DomainFilter.component';
 import { connect } from 'react-redux'
 import { getDomains } from '../../redux/domains/selectors';
 import { AppState } from '../../redux/store';
@@ -7,4 +7,12 @@ const mapStateToProps = (state: AppState) => ({
   domains: getDomains(state)
 })
 
-export default connect(mapStateToProps)(DomainFilter)
+
+type OwnProps = {
+  value: FilterValue;
+  onValueChange?: (value: FilterValue) => void;
+}
+
+
+// @ts-ignore todo(@alexstrat): fix connect typing for outter props
+export default connect<AppState,{}, OwnProps>(mapStateToProps)(DomainFilter)

--- a/src/components/DomainFilter/DomainFilter.test.tsx
+++ b/src/components/DomainFilter/DomainFilter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import DomainFilter from './DomainFilter.component';
+import DomainFilter, { domainsToOptions } from './DomainFilter.component';
 
 describe('components', () => {
   describe('DomainFilter', () => {
@@ -8,6 +8,24 @@ describe('components', () => {
       const wrapper = shallow(<DomainFilter domains={['do']} />);
 
       expect(wrapper.find('select')).toHaveLength(3);
+    })
+  })
+
+  describe('options construction', () => {
+    it('should construct the options properly', () => {
+      const res = domainsToOptions([
+        'US_OK-WOK',
+        'FR_NK-WOL',
+        'FR_OK-NPP',
+        'EN_NK-NRP',
+        'EN_BL-WOL',
+      ]);
+
+      expect(res).toEqual({
+        countries: ['US', 'FR', 'EN'],
+        classifications: ['OK', 'NK', 'BL'],
+        subClassifications: ['WOK', 'WOL', 'NPP', 'NRP'],
+      })
     })
   })
 })

--- a/src/components/DomainFilter/DomainFilter.test.tsx
+++ b/src/components/DomainFilter/DomainFilter.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import DomainFilter, { domainsToOptions } from './DomainFilter.component';
+import DomainFilter, { defaultFilterValue, domainsToOptions } from './DomainFilter.component';
 
 describe('components', () => {
   describe('DomainFilter', () => {
     it('should allow the user to filter', () => {
-      const wrapper = shallow(<DomainFilter domains={['do']} />);
+      const wrapper = shallow(<DomainFilter value={defaultFilterValue} domains={['do']} />);
 
       expect(wrapper.find('select')).toHaveLength(3);
     })

--- a/src/components/DomainFilter/index.tsx
+++ b/src/components/DomainFilter/index.tsx
@@ -1,1 +1,4 @@
+import { FilterValue as _FilterValue } from './DomainFilter.component';
 export { default } from './DomainFilter.container';
+export { defaultFilterValue } from './DomainFilter.component';
+export type FilterValue = _FilterValue;


### PR DESCRIPTION
I did understand the exercise's goal in 2 ways:
- isolate the logic that transforms a list of domains in lists of countries, classifications, subsClassifications so that it can be used in other components
- make the `DomainFilter` component reusable in other parts of the app

For the 1st understanding, I did isolate the logic, export it, and tested it. I could have pursued by providing a way to "inject" theses lists anywhere in the app (via a HOC or React hook).

For the 2nd understanding, i transformed the `DomainFilter` component in a controlled component that can be used anywhere in the app (the options/lists are still extracted from the redux store). I did modify how it's used in `App.tsx` to showcase how it can be used, there, with a React local state, but could have been via Redux state.